### PR TITLE
Fixes #2 - Items marked as removed and re-added on switching chars ...

### DIFF
--- a/Warband-Bank-Log.lua
+++ b/Warband-Bank-Log.lua
@@ -252,10 +252,12 @@ function WBL:GetBankContent(event)
     continuableContainer:ContinueOnLoad(function()
         local tempBank = {}
         for _, item in ipairs(items) do
-            WBL:Debug("Get Bank Content", 3, item:GetItemLink())
-            local chunks = strsplittable(":", item:GetItemLink())
-            chunks[10] = ""
-            chunks[11] = ""
+            local itemLink = item:GetItemLink()
+            WBL:Debug("Get Bank Content", 3, itemLink)
+            local colorNameUsed = itemLink and string.sub(itemLink, 1, 3) == "|cn" and 1 or 0
+            local chunks = strsplittable(":", itemLink)
+            chunks[10 + colorNameUsed] = ""
+            chunks[11 + colorNameUsed] = ""
             local link = table.concat(chunks, ":")
             tempBank[link] = (tempBank[link] or 0) + item:GetStackCount()
         end


### PR DESCRIPTION
Hi,

I think I may have found the glitch.
Since patch 11.2, it seems that the itemLink color is now defined as `|cncolorname:text|r` instead of the old `|cAARRGGBBtext|r` format, which means there’s one more “column” in the string. So the code empties wrong "chunks".

Old (I think — I don’t have actual data from before):
```
|cAARRGGBB|Hitem:232653:::::::::::11::1:28:373:::::|h[Portentous Present]|h|r
```

New:
```
|cnIQ3:|Hitem:232653:::::::::266::11::1:28:373:::::|h[Portentous Present]|h|r
```

This PR should fix that — I hope. I don't know if the old format can be still used so I set the offset `colorNameUsed` variable depending on a color definition.

By the way, I just discovered your addon. Really nice work! 👍