### PR TITLE
Fix for 11.2.5  API (ElementFactory)

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -35,6 +35,9 @@ function WBL:CreateDisplay()
 
     WBL.DataProvider = CreateDataProvider()
     local ScrollView = CreateScrollBoxListLinearView()
+    ScrollView:SetElementFactory(function(factory)
+        factory("WBLItemListObjectTemplate", function() end)
+    end)
     WBL.ScrollView = ScrollView
     ScrollView:SetDataProvider(WBL.DataProvider)
 


### PR DESCRIPTION
Fixes this 11.2.5 error, which prevented the ScrollBox from being populated:

<details>
<summary><code>SetDataProvider() elementFactory was nil. Call SetElementFactory() before setting the data provider.</code></summary>

```denizenscript
3x ...izzard_SharedXML/Shared/Scroll/ScrollBoxListView.lua:292: SetDataProvider() elementFactory was nil. Call SetElementFactory() before setting the data provider.
[Blizzard_SharedXML/Shared/Scroll/ScrollBoxListView.lua]:292: in function 'SetDataProvider'
[Warband-Bank-Log/Display.lua]:39: in function 'CreateDisplay'
[Warband-Bank-Log/Warband-Bank-Log.lua]:63: in function <Warband-Bank-Log/Warband-Bank-Log.lua:41>
[C]: ?
[Blizzard_SharedXMLBase/CallbackRegistry.lua]:144: in function <...eBlizzard_SharedXMLBase/CallbackRegistry.lua:143>
[C]: ?
[Blizzard_SharedXMLBase/CallbackRegistry.lua]:147: in function 'TriggerEvent'
[Blizzard_SharedXMLBase/GlobalCallbackRegistry.lua]:9: in function <...ns/Blizzard_SharedXMLBase/GlobalCallbackRegistry.lua:8>

Locals:
self = <table> {
 frameFactory = <table> {
 }
 Event = <table> {
 }
 templateInfoCache = <table> {
 }
 padding = <table> {
 }
 initializers = <table> {
 }
 FrameLevelPolicy = <table> {
 }
 canSignalWithoutInitializer = true
 frames = <table> {
 }
 initialized = true
 callbackTables = <table> {
 }
}
dataProvider = <table> {
 collection = <table> {
 }
 callbackTables = <table> {
 }
 Event = <table> {
 }
}
retainScrollPosition = nil
InvalidationReason = <table> {
 DataProviderContentsChanged = 2
 DataProviderReassigned = 1
}

```
</details>

Not sure if we need an [initializer](https://warcraft.wiki.gg/wiki/Making_scrollable_frames#Custom_Element_Factories) as 2nd parameter of `factory`. In any case, it works fine with the modification as it is.

You can still replace the empty function, should it turn out that you need one.